### PR TITLE
refactor: Run worker in strict mode

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{js,json}]
+indent_size = 2
+indent_style = space

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 # Spotify OAuth Workers Client
 
 This is a workers service that fetches a user's Spotify playlists for

--- a/app/worker.js
+++ b/app/worker.js
@@ -35,7 +35,7 @@ addEventListener("fetch", event => {
             proceed: false,
             errors: [{ type: "400", message: error.message }]
           })
-        )
+        );
       })
   );
 });
@@ -117,7 +117,7 @@ async function handleRequest(request) {
       });
       return new Response(JSON.stringify({ install, proceed: true }));
     }
-    let auth = ''
+    let auth = "";
     try {
       auth = body.authentications.account.token;
     } catch (error) {
@@ -261,7 +261,7 @@ async function handleRequest(request) {
     return ret;
   }
   ret = app.get("/healthcheck", request => {
-    return new Response(null, {status: 200});
+    return new Response(null, { status: 200 });
   });
   if (ret) {
     return ret;
@@ -270,7 +270,12 @@ async function handleRequest(request) {
   return new Response(
     JSON.stringify({
       proceed: false,
-      errors: [{ type: "route-not-found", message: "route not defined on worker " + request.url }]
+      errors: [
+        {
+          type: "route-not-found",
+          message: "route not defined on worker " + request.url
+        }
+      ]
     })
   );
 }

--- a/app/worker.js
+++ b/app/worker.js
@@ -1,3 +1,10 @@
+"use strict";
+/**
+ * @typedef Item
+ * @property {string} uri
+ * @property {string} name
+ */
+
 /**
  * Constants
  */
@@ -22,12 +29,14 @@ addEventListener("fetch", event => {
   return event.respondWith(
     handleRequest(event.request)
       .then(resp => resp)
-      .catch(error => new Response(
-        JSON.stringify({
-          proceed: false,
-          errors: [{ type: "400", message: error.message }]
-        })
-      ))
+      .catch(error => {
+        return new Response(
+          JSON.stringify({
+            proceed: false,
+            errors: [{ type: "400", message: error.message }]
+          })
+        )
+      })
   );
 });
 
@@ -37,9 +46,14 @@ addEventListener("fetch", event => {
  * @param {Request} request
  */
 async function handleRequest(request) {
-  app = {
+  const app = {
+    /**
+     * @param {string} endpoint
+     * @param {(req: Request) => Response|Promise<Response>} fn
+     * @return {Promise<Response>|Response|null}
+     */
     get: (endpoint, fn) => {
-      url = new URL(request.url);
+      const url = new URL(request.url);
       if (
         (url.pathname == "/spotify" || url.pathname == "/spotify/") &&
         request.method === "GET"
@@ -49,8 +63,13 @@ async function handleRequest(request) {
         return fn(request);
       return null;
     },
+    /**
+     * @param {string} endpoint
+     * @param {(req: Request) => Response|Promise<Response>} fn
+     * @return {Promise<Response>|Response|null}
+     */
     post: (endpoint, fn) => {
-      url = new URL(request.url);
+      const url = new URL(request.url);
       if (
         (url.pathname == "/spotify" || url.pathname == "/spotify/") &&
         request.method === "POST"
@@ -65,11 +84,13 @@ async function handleRequest(request) {
   // ret is the return path the request hits
   let ret = null;
 
-  // Primary OAuth request handler.
-  // This handler fetches the user's Spotify playlists and followed artists,
-  // then populates an install field with the entries.
-  ret = app.post("/", async function (request) {
-    body = await request.json();
+  /**
+   * Primary OAuth request handler.
+   * This handler fetches the user's Spotify playlists and followed artists,
+   * then populates an install field with the entries.
+   */
+  ret = app.post("/", async request => {
+    const body = await request.json();
     const { install } = body;
 
     if (!body.metadata.newValue) {
@@ -129,6 +150,7 @@ async function handleRequest(request) {
         return res.json();
       })
       .then(res => {
+        /** @type {{items:Item[]}} */
         const { items = [] } = res;
         const playlistSchema = Object.assign({}, DEFAULT_PLAYLIST_SCHEMA);
 
@@ -158,6 +180,7 @@ async function handleRequest(request) {
     )
       .then(res => res.json())
       .then(res => {
+        /** @type {{items:Item[]}} */
         const { items = [] } = res.artists;
         const artistSchema = Object.assign({}, DEFAULT_ARTIST_SCHEMA);
 
@@ -198,8 +221,8 @@ async function handleRequest(request) {
   /**
    * Account metadata handler.
    * This handler fetches user info and populates the login entry with user's info.
-    */
-  ret = app.get("/account-metadata", function (request) {
+   */
+  ret = app.get("/account-metadata", async request => {
     return fetch("https://api.spotify.com/v1/me", {
       headers: {
         authorization: request.headers.get("authorization")
@@ -237,8 +260,8 @@ async function handleRequest(request) {
   if (ret) {
     return ret;
   }
-  ret = app.get("/healthcheck", function (request, response) {
-    return new Response(200);
+  ret = app.get("/healthcheck", request => {
+    return new Response(null, {status: 200});
   });
   if (ret) {
     return ret;

--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/cloudflare-apps/spotify-oauth-worker"
+  },
+  "devDependencies": {
+    "prettier": "^1.16.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,21 +2,10 @@
   "name": "spotify-express-oauth-express",
   "version": "1.0.0",
   "description": "A Cloudflare service that fetches a user's Spotify playlists.",
-  "engines": {
-    "node": "6.3.1"
-  },
+  "license": "MIT",
   "private": true,
-  "dependencies": {
-    "body-parser": "1.17.1",
-    "express": "4.13.3",
-    "simple-fetch": "^1.5.0"
-  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/CloudflareApps/SpotifyOAuthExpress"
-  },
-  "license": "MIT",
-  "devDependencies": {
-    "standard": "10.0.2"
+    "url": "https://github.com/cloudflare-apps/spotify-oauth-worker"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,13 @@
+devDependencies:
+  prettier: 1.16.4
+lockfileVersion: 5
+packages:
+  /prettier/1.16.4:
+    dev: true
+    engines:
+      node: '>=4'
+    hasBin: true
+    resolution:
+      integrity: sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
+specifiers:
+  prettier: ^1.16.4


### PR DESCRIPTION
This converts the worker to always run in strict mode.

I’ve also removed all unused dependencies.

Then I’ve switched to using Prettier for code formatting, as this repository already mostly uses its style.

---

review?(@victoriabernard92)